### PR TITLE
pubspec.yaml: Changed git url from git:// to https:// 

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,8 +36,9 @@ dependencies:
   cupertino_icons: ^1.0.2
   window_size: 
     git:
-      url: git://github.com/google/flutter-desktop-embedding.git
+      url: https://github.com/google/flutter-desktop-embedding.git
       path: plugins/window_size
+      ref: 03d957e8b5c99fc83cd4a781031b154ab3de8753
   quiver: ^3.0.1+1
   tuple: ^2.0.0
   file_picker: ^4.1.6


### PR DESCRIPTION
 git:// was causing network errors and timing out/wouldn't install with 'flutter pub get'