### PR TITLE
Mixin preferences: Refactored shared preferences functions to be generic setters/getters used as a mixin

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,6 @@
 import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:quickgui/src/app.dart';
-import 'package:quickgui/src/globals.dart';
 import 'package:quickgui/src/model/operating_system.dart';
 import 'package:quickgui/src/model/option.dart';
 import 'package:quickgui/src/model/version.dart';
@@ -44,7 +42,6 @@ Future<List<OperatingSystem>> loadOperatingSystems(bool showUbuntus) async {
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  Directory.current = gCurrentDirectoy;
   setWindowTitle('Quickgui : a flutter frontend for Quickget and Quickemu');
   setWindowMinSize(const Size(692, 580));
   setWindowMaxSize(const Size(692, 580));

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -7,10 +7,9 @@ class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      theme: ThemeData(
-        primarySwatch: Colors.pink,
-      ),
-      home: const MainPage(title: 'Quickgui - A Flutter frontend for Quickget and Quickemu'),
-    );
+        theme: ThemeData(
+          primarySwatch: Colors.pink,
+        ),
+        home: const MainPage(title: 'Quickgui - A Flutter frontend for Quickget and Quickemu'));
   }
 }

--- a/lib/src/globals.dart
+++ b/lib/src/globals.dart
@@ -1,6 +1,4 @@
 import 'dart:io';
 
-import 'package:flutter/material.dart';
-
 var gIsSnap = Platform.environment['SNAP']?.isNotEmpty ?? false;
-var gCurrentDirectoy = Directory(Platform.environment['HOME'] ?? Directory.current.absolute.path);
+const String prefWorkingDirectory = 'workingDirectory';

--- a/lib/src/mixins/preferences_mixin.dart
+++ b/lib/src/mixins/preferences_mixin.dart
@@ -1,0 +1,16 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+mixin PreferencesMixin {
+  void savePreference(key, value) async {
+    final prefs = await SharedPreferences.getInstance();
+    prefs.setString(key, value);
+  }
+
+  Future getPreference(key) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (prefs.containsKey(key)) {
+      final preference = prefs.getString(key);
+      return preference ?? false;
+    }
+  }
+}

--- a/lib/src/pages/downloader.dart
+++ b/lib/src/pages/downloader.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:quickgui/src/globals.dart';
 import 'package:quickgui/src/model/operating_system.dart';
 import 'package:quickgui/src/model/option.dart';
 import 'package:quickgui/src/model/version.dart';
@@ -37,7 +36,6 @@ class _DownloaderState extends State<Downloader> {
 
   @override
   void initState() {
-    Directory.current = gCurrentDirectoy;
     _progressStream = progressStream();
     super.initState();
   }
@@ -122,7 +120,7 @@ class _DownloaderState extends State<Downloader> {
                     ),
                     Padding(
                       padding: const EdgeInsets.only(top: 32),
-                      child: Text("Target folder : $gCurrentDirectoy"),
+                      child: Text("Target folder : ${Directory.current}"),
                     ),
                   ],
                 );

--- a/lib/src/widgets/home_page/downloader_menu.dart
+++ b/lib/src/widgets/home_page/downloader_menu.dart
@@ -14,6 +14,18 @@ class DownloaderMenu extends StatefulWidget {
 
 class _DownloaderMenuState extends State<DownloaderMenu> with PreferencesMixin {
   @override
+  void initState() {
+    super.initState();
+    getPreference(prefWorkingDirectory).then((pref) {
+      if (pref is String) {
+        setState(() {
+          Directory.current = pref;
+        });
+      }
+    });
+  }
+  
+  @override
   Widget build(BuildContext context) {
     return Expanded(
       child: Container(

--- a/lib/src/widgets/home_page/downloader_menu.dart
+++ b/lib/src/widgets/home_page/downloader_menu.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
-
+import 'package:quickgui/src/globals.dart';
+import 'package:quickgui/src/mixins/preferences_mixin.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:quickgui/src/globals.dart';
 import 'package:quickgui/src/widgets/home_page/home_page_button_group.dart';
 
 class DownloaderMenu extends StatefulWidget {
@@ -12,7 +12,7 @@ class DownloaderMenu extends StatefulWidget {
   State<DownloaderMenu> createState() => _DownloaderMenuState();
 }
 
-class _DownloaderMenuState extends State<DownloaderMenu> {
+class _DownloaderMenuState extends State<DownloaderMenu> with PreferencesMixin {
   @override
   Widget build(BuildContext context) {
     return Expanded(
@@ -40,12 +40,13 @@ class _DownloaderMenuState extends State<DownloaderMenu> {
                 var folder = await FilePicker.platform.getDirectoryPath(dialogTitle: "Pick a folder");
                 if (folder != null) {
                   setState(() {
-                    gCurrentDirectoy = Directory(folder);
+                    Directory.current = folder;
                   });
+                  savePreference(prefWorkingDirectory, Directory.current.path);
                 }
               },
               child: Text(
-                "Working directory : ${gCurrentDirectoy.path}",
+                "Working directory : ${Directory.current.path}",
                 style: Theme.of(context).textTheme.subtitle1!.copyWith(color: Colors.white),
               ),
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,8 +36,9 @@ dependencies:
   cupertino_icons: ^1.0.2
   window_size: 
     git:
-      url: git://github.com/google/flutter-desktop-embedding.git
+      url: https://github.com/google/flutter-desktop-embedding.git
       path: plugins/window_size
+      ref: 03d957e8b5c99fc83cd4a781031b154ab3de8753
   quiver: ^3.0.1+1
   tuple: ^2.0.0
   file_picker: ^4.1.6


### PR DESCRIPTION
Refactored shared preferences functions to be generic setters/getters using key/values to allow for multiple preferences to be stored. Refactored the shared preferences functions as a mixin for ease of use. Directory change is now remembered across the app pages.