### PR TITLE
Small nullability check in manager.dart for null working directory

### DIFF
--- a/lib/src/pages/manager.dart
+++ b/lib/src/pages/manager.dart
@@ -30,6 +30,9 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
     super.initState();
     getPreference<String>(prefWorkingDirectory).then((pref) {
       setState(() {
+        if (pref == null) {
+          return;
+        }
         Directory.current = pref;
       });
       Future.delayed(Duration.zero, () => _getVms(context)); // Reload VM list when we enter the page.


### PR DESCRIPTION
This squashes a potential bad interaction on initial launch that causes at the least a message in the terminal about using a null value instead of string.
