### PR TITLE
Use local imports, not package imports for our own files

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,14 +2,15 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
-import 'package:quickgui/src/app.dart';
-import 'package:quickgui/src/mixins/app_version.dart';
-import 'package:quickgui/src/model/app_theme.dart';
-import 'package:quickgui/src/model/operating_system.dart';
-import 'package:quickgui/src/model/option.dart';
-import 'package:quickgui/src/model/version.dart';
 import 'package:tuple/tuple.dart';
 import 'package:window_size/window_size.dart';
+
+import 'src/app.dart';
+import 'src/mixins/app_version.dart';
+import 'src/model/app_theme.dart';
+import 'src/model/operating_system.dart';
+import 'src/model/option.dart';
+import 'src/model/version.dart';
 
 Future<List<OperatingSystem>> loadOperatingSystems(bool showUbuntus) async {
   var process = await Process.run('quickget', ['list_csv']);

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
-import 'package:quickgui/src/globals.dart';
-import 'package:quickgui/src/i18n/quickgui_localizations_delegate.dart';
-import 'package:quickgui/src/mixins/preferences_mixin.dart';
-import 'package:quickgui/src/model/app_theme.dart';
-import 'package:quickgui/src/pages/main_page.dart';
+
+import 'globals.dart';
+import 'i18n/quickgui_localizations_delegate.dart';
+import 'mixins/preferences_mixin.dart';
+import 'model/app_theme.dart';
+import 'pages/main_page.dart';
 
 class App extends StatefulWidget {
   const App({Key? key}) : super(key: key);

--- a/lib/src/i18n/i18n_ext.dart
+++ b/lib/src/i18n/i18n_ext.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:quickgui/src/i18n/quickgui_localizations.dart';
+
+import 'quickgui_localizations.dart';
 
 extension I18nExt on BuildContext {
   t(String key) => QuickguiLocalizations.of(this).t(key);

--- a/lib/src/i18n/quickgui_localizations_delegate.dart
+++ b/lib/src/i18n/quickgui_localizations_delegate.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:quickgui/src/i18n/quickgui_localizations.dart';
 
-class QuickguiLocalizationsDelegate extends LocalizationsDelegate<QuickguiLocalizations> {
+import 'quickgui_localizations.dart';
+
+class QuickguiLocalizationsDelegate
+    extends LocalizationsDelegate<QuickguiLocalizations> {
   @override
   bool isSupported(Locale locale) => true;
 
@@ -23,5 +25,7 @@ class QuickguiLocalizationsDelegate extends LocalizationsDelegate<QuickguiLocali
   }
 
   @override
-  bool shouldReload(covariant LocalizationsDelegate<QuickguiLocalizations> old) => true;
+  bool shouldReload(
+          covariant LocalizationsDelegate<QuickguiLocalizations> old) =>
+      true;
 }

--- a/lib/src/model/operating_system.dart
+++ b/lib/src/model/operating_system.dart
@@ -1,4 +1,4 @@
-import 'package:quickgui/src/model/version.dart';
+import 'version.dart';
 
 class OperatingSystem {
   OperatingSystem(this.name, this.code) : versions = [];

--- a/lib/src/model/version.dart
+++ b/lib/src/model/version.dart
@@ -1,4 +1,4 @@
-import 'package:quickgui/src/model/option.dart';
+import 'option.dart';
 
 class Version {
   Version(this.version) : options = [];

--- a/lib/src/pages/downloader.dart
+++ b/lib/src/pages/downloader.dart
@@ -3,13 +3,14 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:quickgui/src/model/operating_system.dart';
-import 'package:quickgui/src/model/option.dart';
-import 'package:quickgui/src/model/version.dart';
-import 'package:quickgui/src/widgets/downloader/cancel_dismiss_button.dart';
-import 'package:quickgui/src/widgets/downloader/download_label.dart';
-import 'package:quickgui/src/widgets/downloader/download_progress_bar.dart';
-import 'package:quickgui/src/i18n/i18n_ext.dart';
+
+import '../model/operating_system.dart';
+import '../model/option.dart';
+import '../model/version.dart';
+import '../widgets/downloader/cancel_dismiss_button.dart';
+import '../widgets/downloader/download_label.dart';
+import '../widgets/downloader/download_progress_bar.dart';
+import '../i18n/i18n_ext.dart';
 
 class Downloader extends StatefulWidget {
   const Downloader({

--- a/lib/src/pages/downloader_page.dart
+++ b/lib/src/pages/downloader_page.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:quickgui/src/widgets/home_page/downloader_menu.dart';
-import 'package:quickgui/src/widgets/home_page/logo.dart';
-import 'package:quickgui/src/i18n/i18n_ext.dart';
+
+import '../widgets/home_page/downloader_menu.dart';
+import '../widgets/home_page/logo.dart';
+import '../i18n/i18n_ext.dart';
 
 class DownloaderPage extends StatelessWidget {
   const DownloaderPage({Key? key}) : super(key: key);

--- a/lib/src/pages/main_page.dart
+++ b/lib/src/pages/main_page.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:quickgui/src/widgets/home_page/logo.dart';
-import 'package:quickgui/src/widgets/home_page/main_menu.dart';
-import 'package:quickgui/src/widgets/left_menu.dart';
-import 'package:quickgui/src/i18n/i18n_ext.dart';
+
+import '../widgets/home_page/logo.dart';
+import '../widgets/home_page/main_menu.dart';
+import '../widgets/left_menu.dart';
+import '../i18n/i18n_ext.dart';
 
 class MainPage extends StatefulWidget {
   const MainPage({Key? key, required this.title}) : super(key: key);

--- a/lib/src/pages/manager.dart
+++ b/lib/src/pages/manager.dart
@@ -4,10 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:path/path.dart' as path;
 import 'package:file_picker/file_picker.dart';
 import 'dart:io';
-import 'package:quickgui/src/globals.dart';
-import 'package:quickgui/src/model/vminfo.dart';
-import 'package:quickgui/src/mixins/preferences_mixin.dart';
-import 'package:quickgui/src/i18n/i18n_ext.dart';
+
+import '../globals.dart';
+import '../model/vminfo.dart';
+import '../mixins/preferences_mixin.dart';
+import '../i18n/i18n_ext.dart';
 
 /// VM manager page.
 /// Displays a list of available VMs, running state and connection info,

--- a/lib/src/pages/operating_system_selection.dart
+++ b/lib/src/pages/operating_system_selection.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:quickgui/src/model/operating_system.dart';
-import 'package:quickgui/src/i18n/i18n_ext.dart';
+
+import '../model/operating_system.dart';
+import '../i18n/i18n_ext.dart';
 
 class OperatingSystemSelection extends StatefulWidget {
   const OperatingSystemSelection({Key? key}) : super(key: key);

--- a/lib/src/pages/option_selection.dart
+++ b/lib/src/pages/option_selection.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:quickgui/src/model/version.dart';
-import 'package:quickgui/src/i18n/i18n_ext.dart';
+
+import '../model/version.dart';
+import '../i18n/i18n_ext.dart';
 
 class OptionSelection extends StatefulWidget {
   const OptionSelection(this.version, {Key? key}) : super(key: key);

--- a/lib/src/pages/version_selection.dart
+++ b/lib/src/pages/version_selection.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:quickgui/src/model/operating_system.dart';
-import 'package:quickgui/src/model/option.dart';
-import 'package:quickgui/src/model/version.dart';
-import 'package:quickgui/src/pages/option_selection.dart';
 import 'package:tuple/tuple.dart';
-import 'package:quickgui/src/i18n/i18n_ext.dart';
+
+import '../model/operating_system.dart';
+import '../model/option.dart';
+import '../model/version.dart';
+import '../i18n/i18n_ext.dart';
+import 'option_selection.dart';
 
 class VersionSelection extends StatefulWidget {
   const VersionSelection({Key? key, required this.operatingSystem}) : super(key: key);

--- a/lib/src/widgets/downloader/cancel_dismiss_button.dart
+++ b/lib/src/widgets/downloader/cancel_dismiss_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:quickgui/src/i18n/i18n_ext.dart';
+
+import '../../i18n/i18n_ext.dart';
 
 class CancelDismissButton extends StatelessWidget {
   const CancelDismissButton({

--- a/lib/src/widgets/downloader/download_label.dart
+++ b/lib/src/widgets/downloader/download_label.dart
@@ -1,8 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:quickgui/src/i18n/i18n_ext.dart';
+
+import '../../i18n/i18n_ext.dart';
 
 class DownloadLabel extends StatelessWidget {
-  const DownloadLabel({Key? key, required this.downloadFinished, required this.data, required this.downloader}) : super(key: key);
+  const DownloadLabel(
+      {Key? key,
+      required this.downloadFinished,
+      required this.data,
+      required this.downloader})
+      : super(key: key);
 
   final bool downloadFinished;
   final double? data;

--- a/lib/src/widgets/home_page/downloader_menu.dart
+++ b/lib/src/widgets/home_page/downloader_menu.dart
@@ -1,9 +1,10 @@
 import 'dart:io';
-import 'package:quickgui/src/globals.dart';
-import 'package:quickgui/src/mixins/preferences_mixin.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:quickgui/src/widgets/home_page/home_page_button_group.dart';
+
+import '../../globals.dart';
+import '../../mixins/preferences_mixin.dart';
+import '../home_page/home_page_button_group.dart';
 
 class DownloaderMenu extends StatefulWidget {
   const DownloaderMenu({Key? key}) : super(key: key);

--- a/lib/src/widgets/home_page/home_page_button_group.dart
+++ b/lib/src/widgets/home_page/home_page_button_group.dart
@@ -2,15 +2,16 @@ import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:quickgui/src/model/operating_system.dart';
-import 'package:quickgui/src/model/option.dart';
-import 'package:quickgui/src/model/version.dart';
-import 'package:quickgui/src/pages/downloader.dart';
-import 'package:quickgui/src/pages/operating_system_selection.dart';
-import 'package:quickgui/src/pages/version_selection.dart';
-import 'package:quickgui/src/widgets/home_page/home_page_button.dart';
 import 'package:tuple/tuple.dart';
-import 'package:quickgui/src/i18n/i18n_ext.dart';
+
+import '../../model/operating_system.dart';
+import '../../model/option.dart';
+import '../../model/version.dart';
+import '../../pages/downloader.dart';
+import '../../pages/operating_system_selection.dart';
+import '../../pages/version_selection.dart';
+import '../../i18n/i18n_ext.dart';
+import '../home_page/home_page_button.dart';
 
 class HomePageButtonGroup extends StatefulWidget {
   const HomePageButtonGroup({Key? key}) : super(key: key);

--- a/lib/src/widgets/home_page/main_menu.dart
+++ b/lib/src/widgets/home_page/main_menu.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:quickgui/src/pages/downloader_page.dart';
-import 'package:quickgui/src/pages/manager.dart';
-import 'package:quickgui/src/widgets/home_page/home_page_button.dart';
-import 'package:quickgui/src/i18n/i18n_ext.dart';
+
+import '../../pages/downloader_page.dart';
+import '../../pages/manager.dart';
+import '../../i18n/i18n_ext.dart';
+import '../home_page/home_page_button.dart';
 
 class MainMenu extends StatelessWidget {
   const MainMenu({Key? key}) : super(key: key);

--- a/lib/src/widgets/left_menu.dart
+++ b/lib/src/widgets/left_menu.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:quickgui/src/globals.dart';
-import 'package:quickgui/src/mixins/app_version.dart';
-import 'package:quickgui/src/mixins/preferences_mixin.dart';
-import 'package:quickgui/src/model/app_theme.dart';
-import 'package:quickgui/src/i18n/i18n_ext.dart';
+
+import '../globals.dart';
+import '../mixins/app_version.dart';
+import '../mixins/preferences_mixin.dart';
+import '../model/app_theme.dart';
+import '../i18n/i18n_ext.dart';
 
 class LeftMenu extends StatelessWidget with PreferencesMixin {
   const LeftMenu({Key? key}) : super(key: key);


### PR DESCRIPTION
Following best practice from https://dart.dev/guides/libraries/create-library-packages local imports should not reference our package name, but use relative paths.
