### PR TITLE
Add new action buttons for running VMs

### DIFF
--- a/assets/images/console.svg
+++ b/assets/images/console.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- "console" by Austin Andrews @Templarian from materialdesignicons.com -->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1"  width="24" height="24" viewBox="0 0 24 24">
+    <path fill="#000000" d="M20,19V7H4V19H20M20,3A2,2 0 0,1 22,5V19A2,2 0 0,1 20,21H4A2,2 0 0,1 2,19V5C2,3.89 2.9,3 4,3H20M13,17V15H18V17H13M9.58,13L5.57,9H8.4L11.7,12.3C12.09,12.69 12.09,13.33 11.7,13.72L8.42,17H5.59L9.58,13Z" />
+</svg>

--- a/lib/src/pages/manager.dart
+++ b/lib/src/pages/manager.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:core';
 import 'package:flutter/material.dart';
 import 'package:path/path.dart' as path;
@@ -24,11 +25,14 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
   List<String> _currentVms = [];
   Map<String, VmInfo> _activeVms = {};
   final List<String> _spicyVms = [];
+  final List<String> _sshVms = [];
+  String? _terminalEmulator;
   Timer? refreshTimer;
 
   @override
   void initState() {
     super.initState();
+    _getTerminalEmulator();
     getPreference<String>(prefWorkingDirectory).then((pref) {
       setState(() {
         if (pref == null) {
@@ -38,7 +42,6 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
       });
       Future.delayed(Duration.zero, () => _getVms(context)); // Reload VM list when we enter the page.
     });
-
     refreshTimer = Timer.periodic(const Duration(seconds: 5), (Timer t) {
       _getVms(context);
     }); // Reload VM list every 5 seconds.
@@ -48,6 +51,18 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
   void dispose() {
     refreshTimer?.cancel();
     super.dispose();
+  }
+
+
+  void _getTerminalEmulator() async {
+    ProcessResult result = Process.runSync('x-terminal-emulator', ['-h']);
+    RegExp pattern = RegExp(r"usage:\s+([^\s]+)", multiLine: true, caseSensitive: false);
+    RegExpMatch? match = pattern.firstMatch(result.stdout);
+    if (match != null) {
+      setState(() {
+        _terminalEmulator = match.group(1);
+      });
+    }
   }
 
   VmInfo _parseVmInfo(name) {
@@ -107,6 +122,18 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
     });
   }
 
+  Future<bool> _detectSsh(int port) async {
+    bool isSSH = false;
+    try {
+      Socket socket = await Socket.connect('localhost', port);
+      isSSH = await socket.any((event) => utf8.decode(event).contains('SSH'));
+      socket.close();
+      return isSSH;
+    } catch (exception) {
+      return false;
+    }
+  }
+
   Widget _buildVmList() {
     List<Widget> _widgetList = [];
     _widgetList.add(
@@ -156,12 +183,24 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
   List<Widget> _buildRow(String currentVm) {
     final bool active = _activeVms.containsKey(currentVm);
     final bool spicy = _spicyVms.contains(currentVm);
+    final bool sshy = _sshVms.contains(currentVm);
     VmInfo vmInfo = VmInfo();
     String connectInfo = '';
     if (active) {
       vmInfo = _activeVms[currentVm]!;
-      if (vmInfo.sshPort != null) {
+      if (vmInfo.sshPort != null && _terminalEmulator != null) {
         connectInfo += context.t('SSH port') + ': ' + vmInfo.sshPort! + ' ';
+        _detectSsh(int.parse(vmInfo.sshPort!)).then((sshRunning) {
+          if (sshRunning && !sshy) {
+            setState(() {
+              _sshVms.add(currentVm);
+            });
+          } else if (!sshRunning && sshy) {
+            setState(() {
+              _sshVms.remove(currentVm);
+            });
+          }
+        });
       }
       if (vmInfo.spicePort != null) {
         connectInfo += context.t('SPICE port') + ': ' + vmInfo.spicePort! + ' ';
@@ -257,6 +296,56 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
                 child: Text('Spice'),
                 onPressed: () {
                   Process.start('spicy', ['-p', vmInfo.spicePort!]);
+                },
+              ),
+              TextButton(
+                child: Text('SSH'),
+                onPressed: !sshy ? null : () {
+                  TextEditingController _usernameController = TextEditingController();
+                  showDialog<bool>(
+                    context: context,
+                    builder: (BuildContext context) => AlertDialog(
+                      title: Text('Launch SSH connection to $currentVm'),
+                      content: TextField(
+                        controller: _usernameController,
+                        decoration: const InputDecoration(hintText: "SSH username"),
+                      ),
+                      actions: <Widget>[
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, false),
+                          child: const Text('Cancel'),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, true),
+                          child: const Text('Connect'),
+                        ),
+                      ],
+                    ),
+                  ).then((result) {
+                    result = result ?? false;
+                    if (result) {
+                      List<String> sshArgs = ['ssh', '-p', vmInfo.sshPort!, _usernameController.text + '@localhost'];
+                      switch(_terminalEmulator) {
+                        case 'gnome-terminal':
+                        case 'mate-terminal':
+                          sshArgs.insert(0, '--');
+                          break;
+                        case 'xterm':
+                        case 'konsole':
+                          sshArgs.insert(0, '-e');
+                          break;
+                        case 'terminator':
+                        case 'xfce4-terminal':
+                          sshArgs.insert(0, '-x');
+                          break;
+                        case 'guake':
+                          String command = sshArgs.join(' ');
+                          sshArgs = ['-e', command];
+                          break;
+                      }
+                      Process.start(_terminalEmulator!, sshArgs);
+                    }
+                  });
                 },
               ),
             ]

--- a/lib/src/pages/manager.dart
+++ b/lib/src/pages/manager.dart
@@ -156,9 +156,10 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
   List<Widget> _buildRow(String currentVm) {
     final bool active = _activeVms.containsKey(currentVm);
     final bool spicy = _spicyVms.contains(currentVm);
+    VmInfo vmInfo = VmInfo();
     String connectInfo = '';
     if (active) {
-      VmInfo vmInfo = _activeVms[currentVm]!;
+      vmInfo = _activeVms[currentVm]!;
       if (vmInfo.sshPort != null) {
         connectInfo += context.t('SSH port') + ': ' + vmInfo.sshPort! + ' ';
       }
@@ -249,6 +250,17 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
       if (connectInfo.isNotEmpty)
         ListTile(
           title: Text(connectInfo),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              TextButton(
+                child: Text('Spice'),
+                onPressed: () {
+                  Process.start('spicy', ['-p', vmInfo.spicePort!]);
+                },
+              ),
+            ]
+          )
         ),
       const Divider()
     ];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   flutter_localizations: 
     sdk: flutter
   desktop_notifications: ^0.6.1
+  flutter_svg: ^0.23.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This branch makes the following changes:

- Removes the "Use SPICE" button for each VM in favour of passing `--display spice` by default if the `spicy` client is installed
- Adds a new button to running VMs, to reconnect the display with `spicy`, if it's installed.
- Adds a new button to running VMs, to connect via an SSH session if an SSH server is detected on the guest. This will use the terminal emulator set as `x-terminal-emulator`
- Does some styling changes to the buttons to make them look more consistent with the rest of the app (pink accent for active buttons, etc).

This does add a new SVG icon, and thus the flutter_svg package, to display a console icon for the SSH button. We might want to review this if we include the Yaru icons or another icon set as suggested in #8.

Once merged, this will close #4.