### PR TITLE
ci: Replace magic-nix-cache-action

### DIFF
--- a/.github/workflows/build-quickgui.yml
+++ b/.github/workflows/build-quickgui.yml
@@ -120,9 +120,12 @@ jobs:
       - name: "Checkout 🥡"
         uses: "actions/checkout@v4"
       - name: "Install Nix ❄️"
-        uses: "DeterminateSystems/nix-installer-action@v16"
-      - name: "Enable Magic Nix Cache 🪄"
-        uses: "DeterminateSystems/magic-nix-cache-action@v7"
+        uses: "nixbuild/nix-quick-install-action@v30"
+      - name: "Enable Nix Cache 🪄"
+        uses: "nix-community/cache-nix-action@v6"
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
       - name: "Build with Nix ❄️"
         run: |
           nix build .#quickgui

--- a/.github/workflows/flake-checker.yml
+++ b/.github/workflows/flake-checker.yml
@@ -16,6 +16,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: DeterminateSystems/nix-installer-action@v16
-      - uses: DeterminateSystems/magic-nix-cache-action@v7
+      - uses: nixbuild/nix-quick-install-action@v30
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
       - uses: DeterminateSystems/flake-checker-action@v9

--- a/.github/workflows/flake-updater.yml
+++ b/.github/workflows/flake-updater.yml
@@ -13,8 +13,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: DeterminateSystems/nix-installer-action@v16
-      - uses: DeterminateSystems/magic-nix-cache-action@v7
+      - uses: nixbuild/nix-quick-install-action@v30
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
       - uses: DeterminateSystems/update-flake-lock@v24
         with:
           pr-title: "chore: update flake.lock"

--- a/.github/workflows/publish-quickgui.yml
+++ b/.github/workflows/publish-quickgui.yml
@@ -103,8 +103,11 @@ jobs:
       - uses: "actions/checkout@v4"
         with:
           ref: "${{ (inputs.tag != null) && format('refs/tags/{0}', inputs.tag) || '' }}"
-      - uses: "DeterminateSystems/nix-installer-action@v16"
-      - uses: "DeterminateSystems/magic-nix-cache-action@v7"
+      - uses: nixbuild/nix-quick-install-action@v30
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
       - uses: "DeterminateSystems/flakehub-push@v5"
         with:
           visibility: "public"


### PR DESCRIPTION
# Description

The `DeterminateSystems/magic-nix-cache-action` action has been [deprecated](https://determinate.systems/posts/magic-nix-cache-free-tier-eol/) and no longer works. This PR replaces it with the `nix-community/cache-nix-action` action, which is actively maintained. It also replaces the `DeterminateSystems/nix-installer-action` action with the `nixbuild/nix-quick-install-action` action, which is required for the cache action to work. The cache has been configured to restore based on the runner's OS and architecture, so it should work on any runner.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
