### PR TITLE
feat: Tag newly installed VMs as 'new'

### DIFF
--- a/lib/src/globals.dart
+++ b/lib/src/globals.dart
@@ -4,6 +4,7 @@ var gIsSnap = Platform.environment['SNAP']?.isNotEmpty ?? false;
 const String prefWorkingDirectory = 'workingDirectory';
 const String prefThemeMode = 'themeMode';
 const String prefCurrentLocale = 'currentLocale';
+const String prefNewlyInstalledVms = 'newlyInstalledVms';
 
 Future<String> fetchQuickemuVersion() async {
   // Get the version of quickemu

--- a/lib/src/mixins/preferences_mixin.dart
+++ b/lib/src/mixins/preferences_mixin.dart
@@ -27,7 +27,7 @@ mixin PreferencesMixin {
         return prefs.getInt(key) as T;
       } else if (T == String) {
         return prefs.getString(key) as T;
-      } else if (T == List) {
+      } else if (T == List<String>) {
         return prefs.getStringList(key) as T;
       }
     }

--- a/lib/src/pages/manager.dart
+++ b/lib/src/pages/manager.dart
@@ -54,7 +54,7 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
     'xterm',
   ];
   Timer? refreshTimer;
-  List<String> newVmNames = <String>[];
+  List<String> _newVmNames = <String>[];
 
   @override
   void initState() {
@@ -84,7 +84,7 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
   }
 
   Future<void> _setNewVmName() async {
-    newVmNames =
+    _newVmNames =
         await getPreference<List<String>>(prefNewlyInstalledVms) ?? <String>[];
     // Delete prefNewlyInstalledVms to only display once
     savePreference(prefNewlyInstalledVms, <String>[]);
@@ -259,13 +259,7 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
   List<Widget> _buildRow(String currentVm, Color buttonColor) {
     final bool active = _activeVms.containsKey(currentVm);
     final bool sshy = _sshVms.contains(currentVm);
-
-    print('currentVm: $currentVm');
-    print('newVmNames: $newVmNames');
-
-    final bool newVM = newVmNames.contains(currentVm);
-
-    print('newVM $newVM');
+    final bool newVM = _newVmNames.contains(currentVm);
 
     VmInfo vmInfo = VmInfo();
     String connectInfo = '';

--- a/lib/src/pages/manager.dart
+++ b/lib/src/pages/manager.dart
@@ -9,6 +9,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:gettext_i18n/gettext_i18n.dart';
 import 'package:path/path.dart' as path;
 import 'package:process_run/shell.dart';
+import 'package:quickgui/src/widgets/manager/new_vm_tag.dart';
 import 'package:version/version.dart';
 
 import '../globals.dart';
@@ -20,7 +21,9 @@ import '../model/vminfo.dart';
 /// Displays a list of available VMs, running state and connection info,
 /// with buttons to start and stop VMs.
 class Manager extends StatefulWidget {
-  const Manager({super.key});
+  const Manager({super.key, this.newVmName});
+
+  final String? newVmName;
 
   @override
   State<Manager> createState() => _ManagerState();
@@ -249,6 +252,9 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
   List<Widget> _buildRow(String currentVm, Color buttonColor) {
     final bool active = _activeVms.containsKey(currentVm);
     final bool sshy = _sshVms.contains(currentVm);
+
+    final bool newVM = widget.newVmName == currentVm;
+
     VmInfo vmInfo = VmInfo();
     String connectInfo = '';
     if (active) {
@@ -287,7 +293,12 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
     return <Widget>[
       ListTile(
           leading: osIcon ?? const Icon(Icons.computer, size: 32),
-          title: Text(currentVm),
+          title: Row(
+            children: [
+              Text(currentVm),
+              newVM ? const NewVmTag() : const SizedBox.shrink()
+            ],
+          ),
           trailing: Row(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[

--- a/lib/src/pages/manager.dart
+++ b/lib/src/pages/manager.dart
@@ -21,9 +21,7 @@ import '../model/vminfo.dart';
 /// Displays a list of available VMs, running state and connection info,
 /// with buttons to start and stop VMs.
 class Manager extends StatefulWidget {
-  const Manager({super.key, this.newVmName});
-
-  final String? newVmName;
+  const Manager({super.key});
 
   @override
   State<Manager> createState() => _ManagerState();
@@ -56,12 +54,14 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
     'xterm',
   ];
   Timer? refreshTimer;
+  List<String> newVmNames = <String>[];
 
   @override
   void initState() {
     super.initState();
     _getTerminalEmulator();
     _detectSpice();
+    _setNewVmName();
     getPreference<String>(prefWorkingDirectory).then((pref) {
       setState(() {
         if (pref == null) {
@@ -81,6 +81,13 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
   void dispose() {
     refreshTimer?.cancel();
     super.dispose();
+  }
+
+  Future<void> _setNewVmName() async {
+    newVmNames =
+        await getPreference<List<String>>(prefNewlyInstalledVms) ?? <String>[];
+    // Delete prefNewlyInstalledVms to only display once
+    savePreference(prefNewlyInstalledVms, <String>[]);
   }
 
   void _getTerminalEmulator() async {
@@ -253,7 +260,12 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
     final bool active = _activeVms.containsKey(currentVm);
     final bool sshy = _sshVms.contains(currentVm);
 
-    final bool newVM = widget.newVmName == currentVm;
+    print('currentVm: $currentVm');
+    print('newVmNames: $newVmNames');
+
+    final bool newVM = newVmNames.contains(currentVm);
+
+    print('newVM $newVM');
 
     VmInfo vmInfo = VmInfo();
     String connectInfo = '';

--- a/lib/src/widgets/downloader/manage_machines_after_download_button.dart
+++ b/lib/src/widgets/downloader/manage_machines_after_download_button.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:gettext_i18n/gettext_i18n.dart';
+import 'package:quickgui/src/pages/manager.dart';
+
+class ManageMachinesAfterDownloadButton extends StatelessWidget {
+  const ManageMachinesAfterDownloadButton({
+    required this.downloadFinished,
+    required this.vmName,
+    super.key,
+  });
+
+  final bool downloadFinished;
+  final String vmName;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          downloadFinished
+              ? ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Theme.of(context).colorScheme.surface,
+                    foregroundColor: Theme.of(context).colorScheme.onSurface,
+                  ),
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => Manager(
+                          newVmName: vmName,
+                        ),
+                      ),
+                    );
+                  },
+                  child: Text(context.t('Manage existing machines')),
+                )
+              : const SizedBox.shrink(),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/downloader/manage_machines_after_download_button.dart
+++ b/lib/src/widgets/downloader/manage_machines_after_download_button.dart
@@ -5,12 +5,10 @@ import 'package:quickgui/src/pages/manager.dart';
 class ManageMachinesAfterDownloadButton extends StatelessWidget {
   const ManageMachinesAfterDownloadButton({
     required this.downloadFinished,
-    required this.vmName,
     super.key,
   });
 
   final bool downloadFinished;
-  final String vmName;
 
   @override
   Widget build(BuildContext context) {
@@ -30,9 +28,7 @@ class ManageMachinesAfterDownloadButton extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => Manager(
-                          newVmName: vmName,
-                        ),
+                        builder: (context) => const Manager(),
                       ),
                     );
                   },

--- a/lib/src/widgets/manager/new_vm_tag.dart
+++ b/lib/src/widgets/manager/new_vm_tag.dart
@@ -10,17 +10,8 @@ class NewVmTag extends StatelessWidget {
       child: Row(
         children: [
           Icon(
-            Icons.new_releases,
+            Icons.fiber_new,
             color: Theme.of(context).colorScheme.primary,
-          ),
-          Padding(
-            padding: const EdgeInsets.only(left: 4.0),
-            child: Text(
-              'new',
-              style: TextStyle(
-                color: Theme.of(context).colorScheme.primary,
-              ),
-            ),
           ),
         ],
       ),

--- a/lib/src/widgets/manager/new_vm_tag.dart
+++ b/lib/src/widgets/manager/new_vm_tag.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class NewVmTag extends StatelessWidget {
+  const NewVmTag({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 8.0),
+      child: Row(
+        children: [
+          Icon(
+            Icons.new_releases,
+            color: Theme.of(context).colorScheme.primary,
+          ),
+          Padding(
+            padding: const EdgeInsets.only(left: 4.0),
+            child: Text(
+              'new',
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.primary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,26 +37,26 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   charset:
     dependency: transitive
     description:
@@ -85,18 +85,18 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   console:
     dependency: transitive
     description:
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -385,18 +385,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -433,26 +433,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.16.0"
   msix:
     dependency: transitive
     description:
@@ -510,13 +510,13 @@ packages:
     source: hosted
     version: "0.4.5"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_parsing:
     dependency: transitive
     description:
@@ -713,39 +713,39 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   synchronized:
     dependency: transitive
     description:
@@ -758,18 +758,18 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.4"
   tuple:
     dependency: "direct main"
     description:
@@ -902,10 +902,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.3.1"
   web:
     dependency: transitive
     description:
@@ -956,5 +956,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
-  flutter: ">=3.24.0"
+  dart: ">=3.7.0-0 <4.0.0"
+  flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   cupertino_icons: ^1.0.8
   desktop_notifications: ^0.6.3
   file_picker: ^8.0.6
-  path: ^1.9.1
   flutter_svg: ^2.1.0
+  path: ^1.9.0
   gettext: ^1.2.0
   gettext_i18n: ^1.0.7
   gettext_parser: ^0.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: quickgui
 description: An elegant virtual machine manager for the desktop
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.2.10+1
 
 environment:
@@ -15,6 +15,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   desktop_notifications: ^0.6.3
   file_picker: ^8.0.6
+  path: ^1.9.1
   flutter_svg: ^2.0.17
   gettext: ^1.2.0
   gettext_i18n: ^1.0.7


### PR DESCRIPTION
# Description

Please include a summary of the changes along with any relevant motivation and context.

<!-- Delete if not relevant -->
After downloading a VM, a button appears that takes the user directly to the VM manager page.
Newly downloaded VMs are temporarily marked with the label "new" when the manager page is opened for the first time. The label disappears on subsequent visits.

![image](https://github.com/user-attachments/assets/b342f64b-a1e4-4d02-9086-21d1181db082)


- Closes #73 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

<!-- Delete any that are not relevant -->

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
- [x] I have updated and committed `pubspec.yaml` and `pubspec.lock`
  - `flutter pub get`

*`yq` above is [yq-go](https://github.com/mikefarah/yq)*
